### PR TITLE
Simplify Windows development docs

### DIFF
--- a/docs/develop-logseq-on-windows.md
+++ b/docs/develop-logseq-on-windows.md
@@ -1,65 +1,30 @@
 # Build Logseq Desktop on Windows
 
-## Intro
-This is a guide on creating Logseq development environment on Windows with `PowerShell`. Non-platform specific instructions like [Develop Logseq](develop-logseq.md) **should also be referenced**.
+This is a guide on setting up a Logseq development environment on Windows.
 
 ## Pre-requisites
-* Ensure `Set-ExecutionPolicy Unrestricted` (or other equivalent)
-* Good network connection. Here's [An example of setting up proxy in PowerShell](#an-example-of-setting-up-proxy-in-powershell)
-* Node.js 18.x
-* Clojure (follow this [Guidance](https://clojure.org/guides/getting_started#_installation_on_windows))
-* JRE 8 (required for Clojure)
-* Visual Studio (required for desktop app)
 
-(updated 20230221. May confirm via JAVA_VERSION and NODE_VERSION in [THIS FILE](https://github.com/logseq/logseq/blob/master/.github/workflows/build.yml))
-
-### An example of installing pre-requisites on Windows
-* Install [Chocolatey](https://chocolatey.org/)
-* Install JRE (only x64, x32 will not work)
-* Install NVM for Windows, Node.js, and Yarn
+  * NVM, Node, and Yarn
   ```
-  choco install nvm
-  nvm install 18.12.0 (or whatever version)
-  nvm use 18.12.0
+  winget install --id CoreyButler.NVMforWindows
+  nvm install 18
+  nvm use 18
   npm install -g yarn
-  nvm use 18.12.0
   ```
-* Install [clj-on-windows](https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows)
-
-Congrats! The pre-requisites are ready.
-
-## Set-up development environment (web app)
-
-The basic idea is replacing the `clojure` commands in [package.json](https://github.com/logseq/logseq/blob/master/package.json) to `clj`.
-Go to your cloned Logseq repo. Then install dependencies, execute the `clj` equivalent of `yarn watch`. Refer [THIS](#an-example-of-setting-up-proxy-in-powershell) if you want to setup proxy in `PowerShell`.
-
-* Copy files in `resources` to `static`
-
-* Compile static assets(css, icons...)
+  * Java
   ```
-  yarn add --dev gulp
-  yarn
-  yarn gulp:watch
+  winget install --id Microsoft.OpenJDK.17
   ```
+  * Visual Studio
+  ```
+  winget install --id Microsoft.VisualStudio.2022.Community
+  ```
+  * An installer for clojure is available from [casselc/clj-msi](https://github.com/casselc/clj-msi/releases/)
 
-* Open another powershell window, and run `yarn cljs:watch`. Clojure CLI will pull dependencies from Maven and Clojars, build the app and start the development server. Refer [THIS](#set-up-clojure-cli-repository-mirror) if your network access to Maven and Clojars is unstable.
+## Troubleshooting
 
-Now you can access the app via `http://localhost:3001` and all changes to the code will be watched.
+### Configuring a proxy for internet access
 
-## Set-up development environment (desktop)
-To run the desktop app in development mode, after setting up web app development environment, run following commands which are equivalent to `yarn dev-electron-app`:
-
-```
-cd static
-yarn
-yarn electron:dev
-```
-
-The desktop app should pop-up on your screen.
-
-During the build process `node-gyp` may complain that it cannot find Visual Studio. Try building the app in Developer Powershell for VS(shipped with Visual Studio). If this does not work for you, [This issue](https://github.com/nodejs/node-gyp/issues/2203) may be helpful.
-
-## An example of setting up proxy in PowerShell
 ```
 $env:GLOBAL_AGENT_HTTPS_PROXY='http://<proxy-host>:<proxy-port>'
 $env:ELECTRON_GET_USE_PROXY='true'
@@ -67,7 +32,12 @@ $env:HTTPS_PROXY='http://<proxy-host>:<proxy-port>'
 $env:HTTP_PROXY='http://<proxy-host>:<proxy-port>'
 ```
 
-## Set up Clojure CLI repository mirror
+### node-gyp cannot find visual studio
+
+During the build process `node-gyp` may complain that it cannot find Visual Studio. Try building the app in Developer Powershell for VS(shipped with Visual Studio). If this does not work for you, [This issue](https://github.com/nodejs/node-gyp/issues/2203) may be helpful.
+
+
+### Set up Clojure CLI repository mirror
 
 add the following pair to `deps.edn`:
 


### PR DESCRIPTION
This PR simplifies the Windows development setup documentation.  Specifically:

 * Uses `winget` for installing pre-requisites.  This is installed by default on modern windows and is now the "standard" package manager.
 * Use clj-msi to install clj.exe, rather than the clojure-tools powershell module.  This allows the build to work without modifying package.json
 * Remove build instructions that are out of date and now inconsistent with the develop-logseq.md doc.